### PR TITLE
Update ruby versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
   - 2.3.0
   - 2.4.0
+  - 2.5.0
   - ruby-head


### PR DESCRIPTION
According to https://www.ruby-lang.org/en/downloads/branches/
only these versions are still supported.