### PR TITLE
Indentation of end should be the same as begin

### DIFF
--- a/lib/feed_validator/assertions.rb
+++ b/lib/feed_validator/assertions.rb
@@ -68,7 +68,7 @@ class Test::Unit::TestCase
         return assert(true,'')
       end
       File.open filename, 'w+' do |f| Marshal.dump v.response, f end
-  	end
+    end
     assert(v.valid?, v.valid? ? '' : v.to_s)
   end
 


### PR DESCRIPTION
After seeing this error for a long time I though it's
time to fix it. lib/feed_validator/assertions.rb:71:
warning: mismatched indentations at 'end' with 'begin' at 62